### PR TITLE
feat: add content text in help and terms use pages

### DIFF
--- a/src/presentation/views/help/help-view.tsx
+++ b/src/presentation/views/help/help-view.tsx
@@ -50,10 +50,10 @@ export class HelpView
       <ProfileLayout title="Ajuda" image={getIcon('headset')}>
         <SubTitle style={spacing.subTitle}>Fale conosco:</SubTitle>
         <Paragraph style={spacing.paragraph}>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industrys standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          Disponibilizamos aos usuários os canais de comunicação para que entrem
+          em contato conosco em caso de dúvidas, problemas no aplicativo ou
+          propostas comerciais. O horário de funcionamento da central de ajuda é
+          de segunda à sexta-feira das 09:00 até as 18:00.
         </Paragraph>
         <SubTitle style={spacing.subTitle}>Canais de comunicação:</SubTitle>
         <ContainerComunicationChannel>
@@ -81,7 +81,7 @@ export class HelpView
         <ContainerComunicationChannel>
           <ContainerLabelIcon>
             <Icon source={getIcon('tel')} resizeMode="center" />
-            <Label>Telefone:</Label>
+            <Label>Contato:</Label>
           </ContainerLabelIcon>
           <ContainerLink>
             <LinkComponent

--- a/src/presentation/views/terms-use/terms-use-view.tsx
+++ b/src/presentation/views/terms-use/terms-use-view.tsx
@@ -40,31 +40,29 @@ export class TermsUseView
       <ProfileLayout title="Termos de uso" image={getIcon('document-check')}>
         <SubTitle>Introdução</SubTitle>
         <Paragraph style={spacing.paragraph}>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industrys standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          Concordamos em fornecer a você usuário o serviço da Treefy. O serviço
+          inclui o aplicativo, recursos, serviços e tecnologias que fornecemos
+          para promover a missão da Treefy: Fortificar seu conhecimento para
+          obter um meio ambiente melhor. O serviço é composto pelos seguintes
+          termos:
         </Paragraph>
         <SubTitle>Artigo 1</SubTitle>
         <Paragraph style={spacing.paragraph}>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industrys standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          Não cobramos pelo uso do aplicativo e serviços cobertos por estes
+          termos. A Treefy é um serviço inteiramente gratuíto e nunca haverá
+          cobrança aos usuários que estão cadastradas na plataforma.
         </Paragraph>
         <SubTitle>Artigo 2</SubTitle>
         <Paragraph style={spacing.paragraph}>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industrys standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          Não vendemos seus dados pessoais para anunciantes nem compartilhamos
+          informações pessoais do usuários, como por exemplo: nome, e-mail entre
+          outras informações que estão cadastradas no aplicativo.
         </Paragraph>
         <SubTitle>Artigo 3</SubTitle>
         <Paragraph>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industrys standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          A Treefy se responsabiliza pela proteção dos dados dos usuários e pela
+          manutenção de medidas de segurança, técnicas e administrativas aptas a
+          proteger os dados pessoas dos usuários cadastrados.
         </Paragraph>
         <ButtonComponent
           type="outline"


### PR DESCRIPTION
# Related Issue 
- [Treefy - 62](https://github.com/caioliveira277/treefy/issues/62)

## Proposed changes
Add content in help and terms use pages

## Description
- any

## Screenshots
any